### PR TITLE
Updated media URL

### DIFF
--- a/plugin.video.einthusan/default.py
+++ b/plugin.video.einthusan/default.py
@@ -470,7 +470,7 @@ def preferred_server(lnk, mainurl):
 		xbmc.log(vidpath)
 		new_headers = {'User-Agent':'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36', 'Referer':mainurl, 'Origin':'https://einthusan.ca'}
 		for i in servers:
-			urltry = ("https://" + CDN_PREFIX + str(i+SERVER_OFFSET[0]) + ".einthusan.ca/" + vidpath)
+			urltry = ("https://" + CDN_PREFIX + str(i+SERVER_OFFSET[0]) + ".einthusan.io/" + vidpath)
 
 			isitworking = requests.get(urltry, headers=new_headers).status_code
 			xbmc.log(urltry, level=xbmc.LOGNOTICE)


### PR DESCRIPTION
Modified media URL generation from einthusan.ca to einthusan.io

Further simplification of URL generation may be possible. I will take another look when I have a chance. In the meantime, this fixes the issues with 1.4.7 not loading any videos.

Tested on Kodi 18.2 on FireTV 4K